### PR TITLE
Fix for 'ignores devices if they have same name'

### DIFF
--- a/plejd/mqtt.js
+++ b/plejd/mqtt.js
@@ -35,7 +35,7 @@ const getSettingsTopic = () => `plejd/settings`;
 const getDiscoveryPayload = device => ({
   schema: 'json',
   name: device.name,
-  unique_id: `light.plejd.${device.name.toLowerCase().replace(/ /g, '')}`,
+  unique_id: `light.plejd.${device.name.toLowerCase().replace(/ /g, '')}.${device.id}`,
   state_topic: getStateTopic(device),
   command_topic: getCommandTopic(device),
   optimistic: false,


### PR DESCRIPTION
This change add 'device.id' on identifiers name to avoid mqtt to ignore duplicates. This is related to issue #91.