### PR TITLE
Publish availability of devices

### DIFF
--- a/plejd/main.js
+++ b/plejd/main.js
@@ -27,6 +27,12 @@ async function main() {
   );
   const client = new MqttClient(config.mqttBroker, config.mqttUsername, config.mqttPassword);
 
+  ['SIGINT', 'SIGHUP', 'SIGTERM'].forEach(signal => {
+    process.on(signal, () => {
+      client.disconnect(() => process.exit(0));
+    });
+  });
+
   plejdApi.login().then(() => {
     // load all sites and find the one that we want (from config)
     plejdApi.getSites().then((site) => {


### PR DESCRIPTION
This makes Home Assistant report the devices as unavailable if the add-on is stopped.

Please note that I do not use a supervised install myself, and therefore I can't test if this works as a add-on. Specifically how the signals are handled when a add-on is stopped.