### PR TITLE
multiple fixes for improved lifecycle and errors

### DIFF
--- a/plejd/ble.bluez.js
+++ b/plejd/ble.bluez.js
@@ -60,6 +60,7 @@ class PlejdService extends EventEmitter {
     this.writeQueueWaitTime = writeQueueWaitTime;
     this.writeQueue = [];
     this.writeQueueRef = null;
+    this.delayedInit = null;
 
     this.maxQueueLengthTarget = MAX_WRITEQUEUE_LENGTH_TARGET || this.devices.length || 5;
     logger('Max global transition queue length target', this.maxQueueLengthTarget)

--- a/plejd/ble.bluez.js
+++ b/plejd/ble.bluez.js
@@ -98,7 +98,7 @@ class PlejdService extends EventEmitter {
     };
 
     clearInterval(this.pingRef);
-    clearInterval(this.writeQueueRef);
+    clearTimeout(this.writeQueueRef);
     console.log('init()');
 
     const bluez = await this.bus.getProxyObject(BLUEZ_SERVICE_NAME, '/');
@@ -369,8 +369,8 @@ class PlejdService extends EventEmitter {
     }
 
     // auth done, start ping
-    await this.startPing();
-    await this.startWriteQueue();
+    this.startPing();
+    this.startWriteQueue();
 
     // After we've authenticated, we need to hook up the event listener
     // for changes to lastData.
@@ -414,7 +414,7 @@ class PlejdService extends EventEmitter {
     }
   }
 
-  async startPing() {
+  startPing() {
     console.log('startPing()');
     clearInterval(this.pingRef);
 
@@ -460,9 +460,9 @@ class PlejdService extends EventEmitter {
     this.emit('pingSuccess', pong[0]);
   }
 
-  async startWriteQueue() {
+  startWriteQueue() {
     console.log('startWriteQueue()');
-    clearInterval(this.writeQueueRef);
+    clearTimeout(this.writeQueueRef);
 
     this.writeQueueRef = setTimeout(() => this.runWriteQueue(), this.writeQueueWaitTime);
   }


### PR DESCRIPTION
* Init and _internalInit is actually awaitable
* this.bleDevices is reset on init
* check for actual data in write to preven length of undefined
* Throttled re-inits on write-errors.

This PR is a suggestion for general improvement.

My setup:
5 Plejd-devices and multiple scenes which was very much affected by the https://github.com/icanos/hassio-plejd/issues/134, resulting in weird behaviour where some scene-switches worked halfway and some lights was updateable sometimes in HA.
Basically write was given broken data and reinits was buggy resulting in failed retries.

With this PR both the error (but not the rootcause) is prevented and also general improvements to the lifecycles if other errors would occur.

If this PR is approved it will make the following PR's redundant:
* https://github.com/icanos/hassio-plejd/pull/135
* https://github.com/icanos/hassio-plejd/pull/136