### PR TITLE
Suggested Area and fix for #189

### DIFF
--- a/plejd/CHANGELOG.md
+++ b/plejd/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **BREAKING - READ BELOW FIRST**
 
-Release 0.8 will break ALL EXISTING DEVICES. Unique mqtt id:s will change, meaning HA will create new devices. Scenes will be added as scenes not as switches.
+Release 0.8 will break ALL EXISTING DEVICES. Unique mqtt id:s will change, meaning HA will create new devices. Scenes will be added as scenes not as switches. Devices will be installed to Areas named by the rooms defined in the Plejd app (can be changed)
 
 Recommendations to minimize impact
 
@@ -13,7 +13,7 @@ Recommendations to minimize impact
 - Reboot HA
 - Go to Configuration => Integration => MQTT. Go to entities and after that devices and remove all Plejd devices (should be listed as unavailable)
 - Upgrade addon to latest version and start
-- All devices should now be back. With luck they will have the same HA id:s as before so most things should work. Room assignments, icons, etc will be gone though.
+- All devices should now be back. With luck they will have the same HA id:s as before so most things should work. Room assignments, icons, automations, scenes, etc will have to be gone though.
 
 ## [0.7.1](https://github.com/icanos/hassio-plejd/tree/0.7.1) (2021-03-25)
 

--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -69,6 +69,7 @@ const getOutputDeviceDiscoveryPayload = (
     manufacturer: 'Plejd',
     model: device.typeName,
     name: device.name,
+    ...(device.roomName !== undefined ? { suggested_area: device.roomName } : {}),
     sw_version: device.version,
   },
   ...(device.type === MQTT_TYPES.LIGHT ? { brightness: device.dimmable, schema: 'json' } : {}),

--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -65,7 +65,7 @@ const getOutputDeviceDiscoveryPayload = (
   qos: 1,
   retain: true,
   device: {
-    identifiers: `${device.deviceId}`,
+    identifiers: `${device.uniqueId}`,
     manufacturer: 'Plejd',
     model: device.typeName,
     name: device.name,

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -437,6 +437,7 @@ class PlejdApi {
           }
 
           const room = this.siteDetails.rooms.find((x) => x.roomId === device.roomId);
+          const roomTitle = room ? room.title : undefined;
 
           /** @type {import('types/DeviceRegistry').OutputDevice} */
           const outputDevice = {
@@ -448,7 +449,7 @@ class PlejdApi {
             name: device.title,
             output: deviceOutput,
             roomId: device.roomId,
-            roomName: room.title,
+            roomName: roomTitle,
             state: undefined,
             type: loadType,
             typeName,

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -436,6 +436,8 @@ class PlejdApi {
             loadType = 'light';
           }
 
+          const room = this.siteDetails.rooms.find((x) => x.roomId === device.roomId);
+
           /** @type {import('types/DeviceRegistry').OutputDevice} */
           const outputDevice = {
             bleOutputAddress,
@@ -446,6 +448,7 @@ class PlejdApi {
             name: device.title,
             output: deviceOutput,
             roomId: device.roomId,
+            roomName: room.title,
             state: undefined,
             type: loadType,
             typeName,
@@ -519,6 +522,7 @@ class PlejdApi {
           name: room.title,
           output: undefined,
           roomId,
+          roomName: room.title,
           state: undefined,
           type: 'light',
           typeName: 'Room',
@@ -548,6 +552,7 @@ class PlejdApi {
         name: scene.title,
         output: undefined,
         roomId: undefined,
+        roomName: undefined,
         state: false,
         type: 'scene',
         typeName: 'Scene',

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -522,7 +522,7 @@ class PlejdApi {
           hiddenFromIntegrations: false,
           name: room.title,
           output: undefined,
-          roomId,
+          roomId: undefined,
           roomName: undefined,
           state: undefined,
           type: 'light',

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -523,7 +523,7 @@ class PlejdApi {
           name: room.title,
           output: undefined,
           roomId,
-          roomName: room.title,
+          roomName: undefined,
           state: undefined,
           type: 'light',
           typeName: 'Room',

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -4,29 +4,29 @@ Hass.io add-on for Plejd home automation devices. Gives you the ability to contr
 It uses MQTT to communicate with Home Assistant and supports auto discovery of the devices in range. Changed made in the Plejd app are propagated to Home Assistant.
 
 Plejd output devices typically appears as either lights or switches in Home Assistant depending on how they are configured.
-<table>
-<tr><th align=left>Device</th><th align=left>Plejd Configuration</th><th align=left>Home Assistant Role</th><th align=left>Comment</th></tr>
-<tr><td>CTR-01</td><td>Relay, Light</td><td>Light</td><td></td></tr>
-<tr><td>CTR-01</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
-<tr><td>REL-01</td><td>Relay, Light</td><td>Light</td><td></td></tr>
-<tr><td>REL-01</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
-<tr><td>REL-02</td><td>Relay, Light</td><td>Light</td><td></td></tr>
-<tr><td>REL-02</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
-<tr><td>SPR-01</td><td>Relay, Light</td><td>Light</td><td>Not tested, not released by Plejd</td></tr>
-<tr><td>SPR-01</td><td>Relay, Other</td><td>Switch</td><td>Not tested, not released by Plejd</td></tr>
-<tr><td>DIM-01</td><td>-</td><td>Light</td><td></td></tr>
-<tr><td>DIM-02</td><td>-</td><td>Light</td><td></td></tr>
-<tr><td>LED-10</td><td>-</td><td>Light</td><td></td></tr>
-<tr><td>DAL-01</td><td>-</td><td>-</td><td>Not supported, not released by Plejd</td></tr>
-<tr><td>WPH-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1, button_2,button_3,button_4</td></tr>
-<tr><td>WRT-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1</td></tr>
-<tr><td>GWY-01</td><td>-</td><td>-</td><td></td></tr>
-<tr><td>RTR-01</td><td>-</td><td>-</td><td></td></tr>
-<tr><td>Scene</td><td>-</td><td>Scene</td><td></td></tr>
-<tr><td>Scene</td><td>-</td><td>Device Automation</td><td>type:scene, subtype:trigger</td></tr>
-<tr><td>Room</td><td>-</td><td>Area</td><td>Can be changed by Home Assistant</td></tr>
-<tr><td>Room</td><td>-</td><td>Light</td><td>If includeRoomsAsLights is set to true</td></tr>
-<table>
+
+| Device | Plejd Configuration | Home Assistant Role | Comment                                                               |
+| ------ | ------------------- | ------------------- | --------------------------------------------------------------------- |
+| CTR-01 | Relay, Light        | Light               |                                                                       |
+| CTR-01 | Relay, Other        | Switch              |                                                                       |
+| REL-01 | Relay, Light        | Light               |                                                                       |
+| REL-01 | Relay, Other        | Switch              |                                                                       |
+| REL-02 | Relay, Light        | Light               |                                                                       |
+| REL-02 | Relay, Other        | Switch              |                                                                       |
+| SPR-01 | Relay, Light        | Light               | Not tested, not supported                                             |
+| SPR-01 | Relay, Other        | Switch              | Not tested, not supported                                             |
+| DIM-01 | -                   | Light               |                                                                       |
+| DIM-02 | -                   | Light               |                                                                       |
+| LED-10 | -                   | Light               |                                                                       |
+| DAL-01 | -                   | -                   | Not supported, not released by Plejd                                  |
+| WPH-01 | -                   | Device Automation   | type:button_short_press, subtype:button_1, button_2,button_3,button_4 |
+| WRT-01 | -                   | Device Automation   | type:button_short_press, subtype:button_1                             |
+| GWY-01 | -                   | -                   |                                                                       |
+| RTR-01 | -                   | -                   |                                                                       |
+| Scene  | -                   | Scene               |                                                                       |
+| Scene  | -                   | Device Automation   | type:scene, subtype:trigger                                           |
+| Room   | -                   | Area                | Can be changed by Home Assistant                                      |
+| Room   | -                   | Light               | If includeRoomsAsLights is set to true                                |
 
 Thanks to [ha-plejd](https://github.com/klali/ha-plejd) for inspiration.
 
@@ -133,14 +133,17 @@ If you restore a backup from a 32bit system to a new 64bit system, use the Rebui
 ### Configuration
 
 #### Simple MQTT Configurations
+
 When you are using the official Mosquitto Broker from Home Assistant Add-on store, minimal configuration is required.
-<table>
-<tr><td>mqttBroker</td><td>mqtt://localhost</td></tr>
-<tr><td>mqttUsername</td><td>homeassistant</td></tr>
-<tr><td>mqttPassword</td><td>Mosquitto password, fetched via Configuration->Integrations->Mosquitto broker->Configure->RE-CONFIGURE->Password</td></tr>
-</table>
+
+| Parameter    | Value                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| mqttBroker   | mqtt://localhost                                                                                                 |
+| mqttUsername | homeassistant                                                                                                    |
+| mqttPassword | Mosquitto password, fetched via Configuration->Integrations->Mosquitto broker->Configure->RE-CONFIGURE->Password |
 
 #### Advanced MQTT Configurations
+
 For more advanced instllations, you need to add the MQTT integration to Home Assistant either by going to Configuration -> Integrations and clicking the Add Integration button, or by adding the following to your `configuration.yaml` file:
 
 ```

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -1,9 +1,32 @@
 # Hass.io Plejd add-on
 
 Hass.io add-on for Plejd home automation devices. Gives you the ability to control the Plejd home automation devices through Home Assistant.
-It uses MQTT to communicate with Home Assistant and supports auto discovery of the devices in range.
+It uses MQTT to communicate with Home Assistant and supports auto discovery of the devices in range. Changed made in the Plejd app are propagated to Home Assistant.
 
-It also supports notifications so that changed made in the Plejd app are propagated to Home Assistant.
+Plejd output devices typically appears as either lights or switches in Home Assistant depending on how they are configured.
+<table>
+<tr><th align=left>Device</th><th align=left>Plejd Configuration</th><th align=left>Home Assistant Role</th><th align=left>Comment</th></tr>
+<tr><td>CTR-01</td><td>Relay, Light</td><td>Light</td></tr>
+<tr><td>CTR-01</td><td>Relay, Other</td><td>Switch</td></tr>
+<tr><td>REL-01</td><td>Relay, Light</td><td>Light</td></tr>
+<tr><td>REL-01</td><td>Relay, Other</td><td>Switch</td></tr>
+<tr><td>REL-02</td><td>Relay, Light</td><td>Light</td></tr>
+<tr><td>REL-02</td><td>Relay, Other</td><td>Switch</td></tr>
+<tr><td>SPR-01</td><td>Relay, Light</td><td>Light</td><td>Not tested, not released by Plejd</td></tr>
+<tr><td>SPR-01</td><td>Relay, Other</td><td>Switch</td><td>Not tested, not released by Plejd</td></tr>
+<tr><td>DIM-01</td><td>-</td><td>Light</td></tr>
+<tr><td>DIM-02</td><td>-</td><td>Light</td></tr>
+<tr><td>LED-10</td><td>-</td><td>Light</td></tr>
+<tr><td>DAL-01</td><td>-</td><td>-</td><td>Not supported, not released by Plejd</td></tr>
+<tr><td>WPH-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1, button_2,button_3,button_4</td></tr>
+<tr><td>WRT-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1</td></tr>
+<tr><td>GWY-01</td><td>-</td><td>-</td></tr>
+<tr><td>RTR-01</td><td>-</td><td>-</td></tr>
+<tr><td>Scene</td><td>-</td><td>Scene</td></tr>
+<tr><td>Scene</td><td>-</td><td>Device Automation</td><td>type:scene, subtype:trigger</td></tr>
+<tr><td>Room</td><td>-</td><td>Area</td><td>Can be changed by Home Assistant</td></tr>
+<tr><td>Room</td><td>-</td><td>Light</td><td>If includeRoomsAsLights is set to true</td></tr>
+<table>
 
 Thanks to [ha-plejd](https://github.com/klali/ha-plejd) for inspiration.
 
@@ -41,8 +64,8 @@ The add-on has been tested on the following platforms:
 - CTR-01
 - REL-01
 - REL-02
-- WPH-01 (Note: Available as Device Trigger short_button_press, button_1 .. button_4)
-- WRT-01 (Note: Available as Device Trigger short_button_press, button_1. Rotation/dimming not offered by the device)
+- WPH-01
+- WRT-01
 
 ### Easy Installation
 
@@ -52,6 +75,7 @@ Browse to your Home Assistant installation in a web browser and click on `Hass.i
 - Click on `Add-on Store` in the top navigation bar of that page.
 - Paste the URL to this repo https://github.com/icanos/hassio-plejd.git in the `Add new repository by URL` field and hit `Add`.
 - Scroll down and you should find a Plejd add-on that can be installed. Open that and install.
+- Configure hassio-plejd (see below)
 - Enjoy!
 
 ### Manual Installation
@@ -108,7 +132,16 @@ If you restore a backup from a 32bit system to a new 64bit system, use the Rebui
 
 ### Configuration
 
-You need to add the MQTT integration to Home Assistant either by going to Configuration -> Integrations and clicking the Add Integration button, or by adding the following to your `configuration.yaml` file:
+#### Simple MQTT Configurations
+When you are using the official Mosquitto Broker from Home Assistant Add-on store, minimal configuration is required.
+<table>
+<tr><td>mqttBroker</td><td>mqtt://localhost</td></tr>
+<tr><td>mqttUsername</td><td>homeassistant</td></tr>
+<tr><td>mqttPassword</td><td>Mosquitto password, fetched via Configuration->Integrations->Mosquitto broker->Configure->RE-CONFIGURE->Password</td></tr>
+</table>
+
+#### Advanced MQTT Configurations
+For more advanced instllations, you need to add the MQTT integration to Home Assistant either by going to Configuration -> Integrations and clicking the Add Integration button, or by adding the following to your `configuration.yaml` file:
 
 ```
 mqtt:
@@ -120,6 +153,8 @@ mqtt:
 ```
 
 The above is used to notify the add-on when Home Assistant has started successfully and let the add-on send the discovery response (containing information about all Plejd devices found).
+
+#### Configuration Parameters
 
 The plugin needs you to configure some settings before working. You find these on the Add-on page after you've installed it.
 

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -6,23 +6,23 @@ It uses MQTT to communicate with Home Assistant and supports auto discovery of t
 Plejd output devices typically appears as either lights or switches in Home Assistant depending on how they are configured.
 <table>
 <tr><th align=left>Device</th><th align=left>Plejd Configuration</th><th align=left>Home Assistant Role</th><th align=left>Comment</th></tr>
-<tr><td>CTR-01</td><td>Relay, Light</td><td>Light</td></tr>
-<tr><td>CTR-01</td><td>Relay, Other</td><td>Switch</td></tr>
-<tr><td>REL-01</td><td>Relay, Light</td><td>Light</td></tr>
-<tr><td>REL-01</td><td>Relay, Other</td><td>Switch</td></tr>
-<tr><td>REL-02</td><td>Relay, Light</td><td>Light</td></tr>
-<tr><td>REL-02</td><td>Relay, Other</td><td>Switch</td></tr>
+<tr><td>CTR-01</td><td>Relay, Light</td><td>Light</td><td></td></tr>
+<tr><td>CTR-01</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
+<tr><td>REL-01</td><td>Relay, Light</td><td>Light</td><td></td></tr>
+<tr><td>REL-01</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
+<tr><td>REL-02</td><td>Relay, Light</td><td>Light</td><td></td></tr>
+<tr><td>REL-02</td><td>Relay, Other</td><td>Switch</td><td></td></tr>
 <tr><td>SPR-01</td><td>Relay, Light</td><td>Light</td><td>Not tested, not released by Plejd</td></tr>
 <tr><td>SPR-01</td><td>Relay, Other</td><td>Switch</td><td>Not tested, not released by Plejd</td></tr>
-<tr><td>DIM-01</td><td>-</td><td>Light</td></tr>
-<tr><td>DIM-02</td><td>-</td><td>Light</td></tr>
-<tr><td>LED-10</td><td>-</td><td>Light</td></tr>
+<tr><td>DIM-01</td><td>-</td><td>Light</td><td></td></tr>
+<tr><td>DIM-02</td><td>-</td><td>Light</td><td></td></tr>
+<tr><td>LED-10</td><td>-</td><td>Light</td><td></td></tr>
 <tr><td>DAL-01</td><td>-</td><td>-</td><td>Not supported, not released by Plejd</td></tr>
 <tr><td>WPH-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1, button_2,button_3,button_4</td></tr>
 <tr><td>WRT-01</td><td>-</td><td>Device Automation</td><td>type:button_short_press, subtype:button_1</td></tr>
-<tr><td>GWY-01</td><td>-</td><td>-</td></tr>
-<tr><td>RTR-01</td><td>-</td><td>-</td></tr>
-<tr><td>Scene</td><td>-</td><td>Scene</td></tr>
+<tr><td>GWY-01</td><td>-</td><td>-</td><td></td></tr>
+<tr><td>RTR-01</td><td>-</td><td>-</td><td></td></tr>
+<tr><td>Scene</td><td>-</td><td>Scene</td><td></td></tr>
 <tr><td>Scene</td><td>-</td><td>Device Automation</td><td>type:scene, subtype:trigger</td></tr>
 <tr><td>Room</td><td>-</td><td>Area</td><td>Can be changed by Home Assistant</td></tr>
 <tr><td>Room</td><td>-</td><td>Light</td><td>If includeRoomsAsLights is set to true</td></tr>

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -41,7 +41,8 @@ The add-on has been tested on the following platforms:
 - CTR-01
 - REL-01
 - REL-02
-- WPH-01
+- WPH-01 (Note: Available as Device Trigger short_button_press, button_1 .. button_4)
+- WRT-01 (Note: Available as Device Trigger short_button_press, button_1. Rotation/dimming not offered by the device)
 
 ### Easy Installation
 

--- a/plejd/types/DeviceRegistry.d.ts
+++ b/plejd/types/DeviceRegistry.d.ts
@@ -13,6 +13,7 @@ export interface OutputDevice {
   name: string;
   output: number;
   roomId: string;
+  roomName: string;
   state: boolean | undefined;
   type: string;
   typeName: string;

--- a/plejd/types/DeviceRegistry.d.ts
+++ b/plejd/types/DeviceRegistry.d.ts
@@ -12,8 +12,8 @@ export interface OutputDevice {
   hiddenFromSceneList?: boolean;
   name: string;
   output: number;
-  roomId: string;
-  roomName: string;
+  roomId: string | undefined;
+  roomName: string | undefined;
   state: boolean | undefined;
   type: string;
   typeName: string;


### PR DESCRIPTION
Plejd Rooms are configured in Home Assistant as Suggested Area.

Includes disputed change in `plejd/MqttClient.js`:
```
-    identifiers: `${device.deviceId}`,
+    identifiers: `${device.uniqueId}`,
```

Without it it the PR will not work properly, amongs other things as indicated in this [comment](https://github.com/icanos/hassio-plejd/pull/179#issuecomment-834286512).

Improved documentation inc. suggested updated instruction for Mosquitto to resolve #189 