### PR TITLE
fix build issue with latest hassio version

### DIFF
--- a/plejd/Dockerfile
+++ b/plejd/Dockerfile
@@ -25,6 +25,7 @@ RUN \
   python3 \
   bluez \
   eudev-dev \
+  zlib-dev \
   \
   && apk add --no-cache \
   git \


### PR DESCRIPTION
adding zlib-dev dependency to the dockerfile solves recent build issues with latest hassio version.

while this PR is under review, a manual fix is to do a manual install according to the readme file and then manually replace the docker file after copying the files into the addon\hassio-plejd folder.