### PR TITLE
MQTT startup bugfix

### DIFF
--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events');
-const fs = require('fs');
 const mqtt = require('mqtt');
 
 const Configuration = require('./Configuration');
@@ -11,8 +10,6 @@ const logger = Logger.getLogger('plejd-mqtt');
 
 const discoveryPrefix = 'homeassistant';
 const nodeId = 'plejd';
-
-const SYSTEM_ID = fs.readFileSync('/sys/class/dmi/id/board_serial').toString();
 
 /** @type {import('./types/Mqtt').MQTT_TYPES} */
 const MQTT_TYPES = {
@@ -155,7 +152,7 @@ class MqttClient extends EventEmitter {
     logger.info('Initializing MQTT connection for Plejd addon');
 
     this.client = mqtt.connect(this.config.mqttBroker, {
-      clientId: `hassio-plejd_${SYSTEM_ID}`,
+      clientId: `hassio-plejd_${Math.random().toString(16).substr(2, 8)}`,
       password: this.config.mqttPassword,
       protocolVersion: 4, // v5 not supported by HassIO Mosquitto
       queueQoSZero: true,

--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events');
+const fs = require('fs');
 const mqtt = require('mqtt');
 
 const Configuration = require('./Configuration');
@@ -10,6 +11,8 @@ const logger = Logger.getLogger('plejd-mqtt');
 
 const discoveryPrefix = 'homeassistant';
 const nodeId = 'plejd';
+
+const SYSTEM_ID = fs.readFileSync('/sys/class/dmi/id/board_serial').toString();
 
 /** @type {import('./types/Mqtt').MQTT_TYPES} */
 const MQTT_TYPES = {
@@ -152,7 +155,7 @@ class MqttClient extends EventEmitter {
     logger.info('Initializing MQTT connection for Plejd addon');
 
     this.client = mqtt.connect(this.config.mqttBroker, {
-      clientId: `hassio-plejd_${Math.random().toString(16).substr(2, 8)}`,
+      clientId: `hassio-plejd_${SYSTEM_ID}`,
       password: this.config.mqttPassword,
       protocolVersion: 4, // v5 not supported by HassIO Mosquitto
       queueQoSZero: true,


### PR DESCRIPTION
I got this [issue](https://github.com/icanos/hassio-plejd/issues/218) myself where lights would automatically would turn on when HA restarted.

It seems like the problem is that when the MQTT client is set up it's directly hooked up to listen to updates from MQTT even before we do the HA "discovery". The discovery sends things to MQTT and it seems to trigger the unwanted update where we will receive state changes on lights when they actually didn't change at all.

There are many ways to fix this problem but I figured it would be easiest to just ignore any incoming messages from MQTT while the discovery is running.

I tried this at home and before this fix I had the bug described in the issue:
1. Turning on a light in HA
2. Restarting the Plejd add-on
3. Turning off the light with the Plejd app
4. When the Plejd add-on starts up it turns on the light

With this fix the light no longer comes on.