### PR TITLE
Release 0.11.0

### DIFF
--- a/plejd/CHANGELOG.md
+++ b/plejd/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog hassio-plejd Home Assistant Plejd addon
 
-## [0.10.0](https://github.com/icanos/hassio-plejd/tree/0.10.0)
+## [0.11.0](https://github.com/icanos/hassio-plejd/tree/0.11.0) (2023-10-06)
+
+[Full Changelog](https://github.com/icanos/hassio-plejd/compare/0.10.0...0.11.0)
+
+**Closed issues:**
+
+- DWN-01 [\#287](https://github.com/icanos/hassio-plejd/issues/287)
+- Lights detected but cannot control them via HA. Going to unknown / unavailable in MQTT logbook [\#285](https://github.com/icanos/hassio-plejd/issues/285)
+- 0.10.0 breaks DAL-01 [\#284](https://github.com/icanos/hassio-plejd/issues/284)
+- Seems to just be looping [\#283](https://github.com/icanos/hassio-plejd/issues/283)
+- Failed to start discovery. Operation already in progress [\#282](https://github.com/icanos/hassio-plejd/issues/282)
+- Warning after HASS upgrade to 2023.8 [\#279](https://github.com/icanos/hassio-plejd/issues/279)
+- Discovery timeout because of gateway [\#278](https://github.com/icanos/hassio-plejd/issues/278)
+- Non-existing fields of connectedDevice are accessed in PlejdBLEHandler.js breaking time sync [\#265](https://github.com/icanos/hassio-plejd/issues/265)
+- Unable to retrieve session token response: Request failed with status code 404 [\#264](https://github.com/icanos/hassio-plejd/issues/264)
+- Used to work, can't find suitable bt device [\#263](https://github.com/icanos/hassio-plejd/issues/263)
+- Reconnecting loop keeps going after devices found, this makes them unavailable. [\#261](https://github.com/icanos/hassio-plejd/issues/261)
+- disconnecting after a few days [\#252](https://github.com/icanos/hassio-plejd/issues/252)
+
+## [0.10.0](https://github.com/icanos/hassio-plejd/tree/0.10.0) (2023-08-22)
 
 [Full Changelog](https://github.com/icanos/hassio-plejd/compare/0.9.1...0.10.0)
 

--- a/plejd/DeviceRegistry.js
+++ b/plejd/DeviceRegistry.js
@@ -49,6 +49,14 @@ class DeviceRegistry {
 
   /** @param outputDevice {import('types/DeviceRegistry').OutputDevice} */
   addOutputDevice(outputDevice) {
+    const alreadyExistingBLEDevice = this.getOutputDeviceByBleOutputAddress(outputDevice.bleOutputAddress);
+    if (alreadyExistingBLEDevice) {
+      logger.warn(`Device with output id ${outputDevice.bleOutputAddress} already exists named ${alreadyExistingBLEDevice.name}. These two devices are probably grouped in the Plejd app. If this seems to be an error, please log a GitHub issue.`);
+      logger.info(`NOT adding ${outputDevice.name} to device registry`);
+      logger.verbose(`Details of device NOT added: ${JSON.stringify(outputDevice)}`);
+      return;
+    }
+
     this.outputDevices = {
       ...this.outputDevices,
       [outputDevice.uniqueId]: outputDevice,

--- a/plejd/DeviceRegistry.js
+++ b/plejd/DeviceRegistry.js
@@ -7,6 +7,8 @@ class DeviceRegistry {
 
   /** @private @type {Object.<string, import('types/ApiSite').Device>} */
   devices = {};
+  /** @private @type {Object.<string, number>} */
+  mainBleIdByDeviceId = {};
   /** @private @type {Object.<string, string[]>} */
   outputDeviceUniqueIdsByRoomId = {};
   /** @private @type {Object.<number, string>} */
@@ -45,6 +47,10 @@ class DeviceRegistry {
     this.outputUniqueIdByBleOutputAddress[
       this.getUniqueBLEId(inputDevice.bleInputAddress, inputDevice.input)
     ] = inputDevice.uniqueId;
+
+    if (!this.mainBleIdByDeviceId[inputDevice.deviceId]) {
+      this.mainBleIdByDeviceId[inputDevice.deviceId] = inputDevice.bleInputAddress;
+    }
   }
 
   /** @param outputDevice {import('types/DeviceRegistry').OutputDevice} */
@@ -69,6 +75,9 @@ class DeviceRegistry {
     );
 
     this.outputUniqueIdByBleOutputAddress[outputDevice.bleOutputAddress] = outputDevice.uniqueId;
+    if (!this.mainBleIdByDeviceId[outputDevice.deviceId]) {
+      this.mainBleIdByDeviceId[outputDevice.deviceId] = outputDevice.bleOutputAddress;
+    }
 
     if (!this.outputDeviceUniqueIdsByRoomId[outputDevice.roomId]) {
       this.outputDeviceUniqueIdsByRoomId[outputDevice.roomId] = [];
@@ -178,6 +187,14 @@ class DeviceRegistry {
   getInputDeviceName(uniqueInputId) {
     return (this.inputDevices[uniqueInputId] || {}).name;
   }
+
+  /**
+   * @param {string} deviceId
+   */
+  getMainBleIdByDeviceId(deviceId) {
+    return this.mainBleIdByDeviceId[deviceId];
+  }
+
 
   /**
    * @param {string } deviceId The physical device serial number

--- a/plejd/DeviceRegistry.js
+++ b/plejd/DeviceRegistry.js
@@ -55,9 +55,13 @@ class DeviceRegistry {
 
   /** @param outputDevice {import('types/DeviceRegistry').OutputDevice} */
   addOutputDevice(outputDevice) {
-    const alreadyExistingBLEDevice = this.getOutputDeviceByBleOutputAddress(outputDevice.bleOutputAddress);
+    const alreadyExistingBLEDevice = this.getOutputDeviceByBleOutputAddress(
+      outputDevice.bleOutputAddress,
+    );
     if (alreadyExistingBLEDevice) {
-      logger.warn(`Device with output id ${outputDevice.bleOutputAddress} already exists named ${alreadyExistingBLEDevice.name}. These two devices are probably grouped in the Plejd app. If this seems to be an error, please log a GitHub issue.`);
+      logger.warn(
+        `Device with output id ${outputDevice.bleOutputAddress} already exists named ${alreadyExistingBLEDevice.name}. These two devices are probably grouped in the Plejd app. If this seems to be an error, please log a GitHub issue.`,
+      );
       logger.info(`NOT adding ${outputDevice.name} to device registry`);
       logger.verbose(`Details of device NOT added: ${JSON.stringify(outputDevice)}`);
       return;
@@ -194,7 +198,6 @@ class DeviceRegistry {
   getMainBleIdByDeviceId(deviceId) {
     return this.mainBleIdByDeviceId[deviceId];
   }
-
 
   /**
    * @param {string } deviceId The physical device serial number

--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -58,7 +58,7 @@ const decodeTopic = (topic) => {
 const getOutputDeviceDiscoveryPayload = (
   /** @type {import('./types/DeviceRegistry').OutputDevice} */ device,
 ) => ({
-  name: device.name,
+  name: null,
   unique_id: device.uniqueId,
   '~': getBaseTopic(device.uniqueId, device.type),
   state_topic: `~/${TOPIC_TYPES.STATE}`,

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -389,8 +389,33 @@ class PlejdApi {
           dimmable: true,
           broadcastClicks: false,
         };
+      case 167:
+        return {
+          name: 'DWN-01',
+          description: 'Smart tunable downlight with a built-in dimmer function, 8W',
+          type: 'light',
+          dimmable: true,
+          broadcastClicks: false,
+        };
+      // PLEASE CREATE AN ISSUE WITH THE HARDWARE ID if you own one of these devices!
+      // case 
+      //   return {
+      //     name: 'DWN-02',
+      //     description: 'Smart tunable downlight with a built-in dimmer function, 8W',
+      //     type: 'light',
+      //     dimmable: true,
+      //     broadcastClicks: false,
+      //   };
+      // case 
+      //   return {
+      //     name: 'OUT-01',
+      //     description: 'Outdoor wall light with built-in LED, 2x5W',
+      //     type: 'light',
+      //     dimmable: true,
+      //     broadcastClicks: false,
+      //   };
       default:
-        throw new Error(`Unknown device type with id ${plejdDevice.hardwareId}`);
+        throw new Error(`Unknown device type with hardware id ${plejdDevice.hardwareId}. --- PLEASE POST THIS AND THE NEXT LOG ROWS to https://github.com/icanos/hassio-plejd/issues/ --- `);
     }
   }
 

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -398,7 +398,7 @@ class PlejdApi {
           broadcastClicks: false,
         };
       // PLEASE CREATE AN ISSUE WITH THE HARDWARE ID if you own one of these devices!
-      // case 
+      // case
       //   return {
       //     name: 'DWN-02',
       //     description: 'Smart tunable downlight with a built-in dimmer function, 8W',
@@ -406,7 +406,7 @@ class PlejdApi {
       //     dimmable: true,
       //     broadcastClicks: false,
       //   };
-      // case 
+      // case
       //   return {
       //     name: 'OUT-01',
       //     description: 'Outdoor wall light with built-in LED, 2x5W',
@@ -415,7 +415,9 @@ class PlejdApi {
       //     broadcastClicks: false,
       //   };
       default:
-        throw new Error(`Unknown device type with hardware id ${plejdDevice.hardwareId}. --- PLEASE POST THIS AND THE NEXT LOG ROWS to https://github.com/icanos/hassio-plejd/issues/ --- `);
+        throw new Error(
+          `Unknown device type with hardware id ${plejdDevice.hardwareId}. --- PLEASE POST THIS AND THE NEXT LOG ROWS to https://github.com/icanos/hassio-plejd/issues/ --- `,
+        );
     }
   }
 

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -332,17 +332,14 @@ class PlejdApi {
           dimmable: true,
           broadcastClicks: false,
         };
-      // DAL-01 is presumably a very special device
-      // Please open a new issue if you have ideas on how to handel
-      // Below could be use as testing, but since one device can have up to 64 slaves it probably won't work
-      // case 12:
-      //   return {
-      //     name: 'DAL-01',
-      //     description: 'Dali broadcast with dimmer and tuneable white support',
-      //     type: 'light',
-      //     dimmable: true,
-      //     broadcastClicks: false,
-      //   };
+      case 12:
+        return {
+          name: 'DAL-01',
+          description: 'Dali broadcast with dimmer and tuneable white support',
+          type: 'light',
+          dimmable: true,
+          broadcastClicks: false,
+        };
       case 14:
         return {
           name: 'DIM-01',

--- a/plejd/PlejdBLEHandler.js
+++ b/plejd/PlejdBLEHandler.js
@@ -778,10 +778,14 @@ class PlejBLEHandler extends EventEmitter {
     }
 
     this.connectedDevice = device.device;
-    this.connectedDeviceId = this.deviceRegistry.getMainBleIdByDeviceId(this.connectedDevice.deviceId);
+    this.connectedDeviceId = this.deviceRegistry.getMainBleIdByDeviceId(
+      this.connectedDevice.deviceId,
+    );
 
     logger.verbose('The connected Plejd device has the right charecteristics!');
-    logger.info(`Connected to Plejd device ${this.connectedDevice.title} (${this.connectedDevice.deviceId}, BLE id ${this.connectedDeviceId}).`);
+    logger.info(
+      `Connected to Plejd device ${this.connectedDevice.title} (${this.connectedDevice.deviceId}, BLE id ${this.connectedDeviceId}).`,
+    );
 
     await this._authenticate();
 
@@ -820,13 +824,18 @@ class PlejBLEHandler extends EventEmitter {
     // Bytes 2-3 is Command/Request
     const cmd = decoded.readUInt16BE(3);
 
-    const state = decoded.length > PAYLOAD_POSITION_OFFSET ? decoded.readUInt8(PAYLOAD_POSITION_OFFSET) : 0;
+    const state =
+      decoded.length > PAYLOAD_POSITION_OFFSET ? decoded.readUInt8(PAYLOAD_POSITION_OFFSET) : 0;
 
-    const dim = decoded.length > DIM_LEVEL_POSITION_OFFSET ? decoded.readUInt8(DIM_LEVEL_POSITION_OFFSET) : 0;
+    const dim =
+      decoded.length > DIM_LEVEL_POSITION_OFFSET ? decoded.readUInt8(DIM_LEVEL_POSITION_OFFSET) : 0;
 
     if (Logger.shouldLog('silly')) {
       // Full dim level is 2 bytes, we could potentially use this
-      const dimFull = decoded.length > DIM_LEVEL_POSITION_OFFSET ? decoded.readUInt16LE(DIM_LEVEL_POSITION_OFFSET - 1) : 0;
+      const dimFull =
+        decoded.length > DIM_LEVEL_POSITION_OFFSET
+          ? decoded.readUInt16LE(DIM_LEVEL_POSITION_OFFSET - 1)
+          : 0;
       logger.silly(`Dim: ${dim.toString(16)}, full precision: ${dimFull.toString(16)}`);
     }
 
@@ -877,7 +886,6 @@ class PlejBLEHandler extends EventEmitter {
       data = { sceneId: scene.uniqueId };
       this.emit(PlejBLEHandler.EVENTS.commandReceived, outputUniqueId, command, data);
     } else if (cmd === BLE_CMD_TIME_UPDATE) {
-
       if (decoded.length < PAYLOAD_POSITION_OFFSET + 4) {
         if (Logger.shouldLog('debug')) {
           // decoded.toString() could potentially be expensive
@@ -886,13 +894,14 @@ class PlejBLEHandler extends EventEmitter {
         // ignore the notification since too small
         return;
       }
-  
+
       const now = new Date();
       // Guess Plejd timezone based on HA time zone
       const offsetSecondsGuess = now.getTimezoneOffset() * 60 + 250; // Todo: 4 min off
 
       // Plejd reports local unix timestamp adjust to local time zone
-      const plejdTimestampUTC = (decoded.readInt32LE(PAYLOAD_POSITION_OFFSET) + offsetSecondsGuess) * 1000;
+      const plejdTimestampUTC =
+        (decoded.readInt32LE(PAYLOAD_POSITION_OFFSET) + offsetSecondsGuess) * 1000;
       const diffSeconds = Math.round((plejdTimestampUTC - now.getTime()) / 1000);
       if (
         bleOutputAddress !== BLE_BROADCAST_DEVICE_ID ||

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -145,6 +145,7 @@ Plejd output devices typically appears as either lights or switches in Home Assi
 | LED-10    | -                   | Light               |                                                                       |
 | LED-75    | -                   | Light               |                                                                       |
 | DAL-01    | -                   | Light               |                                                                       |
+| DWN-01    | -                   | Light               |                                                                       |
 | WPH-01    | -                   | Device Automation   | type:button_short_press, subtype:button_1, button_2,button_3,button_4 |
 | WRT-01    | -                   | Device Automation   | type:button_short_press, subtype:button_1                             |
 | GWY-01    | -                   | -                   |                                                                       |

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -144,7 +144,7 @@ Plejd output devices typically appears as either lights or switches in Home Assi
 | DIM-02    | -                   | Light               |                                                                       |
 | LED-10    | -                   | Light               |                                                                       |
 | LED-75    | -                   | Light               |                                                                       |
-| DAL-01    | -                   | -                   | Not tested, not supported                                             |
+| DAL-01    | -                   | Light               |                                                                       |
 | WPH-01    | -                   | Device Automation   | type:button_short_press, subtype:button_1, button_2,button_3,button_4 |
 | WRT-01    | -                   | Device Automation   | type:button_short_press, subtype:button_1                             |
 | GWY-01    | -                   | -                   |                                                                       |

--- a/plejd/config.json
+++ b/plejd/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Plejd",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "slug": "plejd",
   "description": "Adds support for the Swedish home automation devices from Plejd.",
   "url": "https://github.com/icanos/hassio-plejd/",


### PR DESCRIPTION
## [0.11.0](https://github.com/icanos/hassio-plejd/tree/0.11.0) (2023-10-06)

[Full Changelog](https://github.com/icanos/hassio-plejd/compare/0.10.0...0.11.0)

**Closed issues:**

- DWN-01 [\#287](https://github.com/icanos/hassio-plejd/issues/287)
- Lights detected but cannot control them via HA. Going to unknown / unavailable in MQTT logbook [\#285](https://github.com/icanos/hassio-plejd/issues/285)
- 0.10.0 breaks DAL-01 [\#284](https://github.com/icanos/hassio-plejd/issues/284)
- Seems to just be looping [\#283](https://github.com/icanos/hassio-plejd/issues/283)
- Failed to start discovery. Operation already in progress [\#282](https://github.com/icanos/hassio-plejd/issues/282)
- Warning after HASS upgrade to 2023.8 [\#279](https://github.com/icanos/hassio-plejd/issues/279)
- Discovery timeout because of gateway [\#278](https://github.com/icanos/hassio-plejd/issues/278)
- Non-existing fields of connectedDevice are accessed in PlejdBLEHandler.js breaking time sync [\#265](https://github.com/icanos/hassio-plejd/issues/265)
- Unable to retrieve session token response: Request failed with status code 404 [\#264](https://github.com/icanos/hassio-plejd/issues/264)
- Used to work, can't find suitable bt device [\#263](https://github.com/icanos/hassio-plejd/issues/263)
- Reconnecting loop keeps going after devices found, this makes them unavailable. [\#261](https://github.com/icanos/hassio-plejd/issues/261)
- disconnecting after a few days [\#252](https://github.com/icanos/hassio-plejd/issues/252)
