### PR TITLE
Improve MQTT startup behavior to disallow Home Assistant from setting new light state during startup

### DIFF
--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -65,7 +65,7 @@ const getOutputDeviceDiscoveryPayload = (
   availability_topic: `~/${TOPIC_TYPES.AVAILABILITY}`,
   optimistic: false,
   qos: 1,
-  retain: true,
+  retain: true, // Discovery messages should be retained to account for HA restarts
   device: {
     identifiers: `${device.uniqueId}`,
     manufacturer: 'Plejd',
@@ -87,7 +87,7 @@ const getSceneDiscoveryPayload = (
   availability_topic: `~/${TOPIC_TYPES.AVAILABILITY}`,
   payload_on: 'ON',
   qos: 1,
-  retain: false,
+  retain: true,  // Discovery messages should be retained to account for HA restarts
 });
 
 const getInputDeviceTriggerDiscoveryPayload = (
@@ -97,9 +97,10 @@ const getInputDeviceTriggerDiscoveryPayload = (
   payload: `${inputDevice.input}`,
   '~': getBaseTopic(inputDevice.deviceId, MQTT_TYPES.DEVICE_AUTOMATION),
   qos: 1,
+  retain: true,  // Discovery messages should be retained to account for HA restarts
+  subtype: `button_${inputDevice.input + 1}`,
   topic: `~/${TOPIC_TYPES.STATE}`,
   type: 'button_short_press',
-  subtype: `button_${inputDevice.input + 1}`,
   device: {
     identifiers: `${inputDevice.deviceId}`,
     manufacturer: 'Plejd',
@@ -114,6 +115,7 @@ const getSceneDeviceTriggerhDiscoveryPayload = (
   automation_type: 'trigger',
   '~': getBaseTopic(`${sceneDevice.uniqueId}_trig`, MQTT_TYPES.DEVICE_AUTOMATION),
   qos: 1,
+  retain: true,  // Discovery messages should be retained to account for HA restarts
   topic: `~/${TOPIC_TYPES.STATE}`,
   type: 'scene',
   subtype: 'trigger',
@@ -151,9 +153,13 @@ class MqttClient extends EventEmitter {
     logger.info('Initializing MQTT connection for Plejd addon');
 
     this.client = mqtt.connect(this.config.mqttBroker, {
+      clean: true, // We're moving not saving mqtt messages
       clientId: `hassio-plejd_${Math.random().toString(16).substr(2, 8)}`,
       password: this.config.mqttPassword,
-      protocolVersion: 4, // v5 not supported by HassIO Mosquitto
+      properties: {
+        sessionExpiryInterval: 120, // 2 minutes sessions for the QoS, after that old messages are discarded
+      },
+      protocolVersion: 5,
       queueQoSZero: true,
       username: this.config.mqttUsername,
     });
@@ -167,12 +173,12 @@ class MqttClient extends EventEmitter {
 
       this.client.subscribe(
         startTopics,
-        // Add below when mqtt v5 is supported in Mosquitto 1.6 or 2.0 and forward
-        // {
-        //   qos: 1,
-        //   nl: true,  // don't echo back messages sent
-        //   rap: true, // retain as published - don't force retain = 0
-        // },
+        {
+          qos: 1,
+          nl: true,  // don't echo back messages sent
+          rap: true, // retain as published - don't force retain = 0
+          rh: 0, // Retain handling 0 presumably ignores retained messages
+        },
         (err) => {
           if (err) {
             logger.error('Unable to subscribe to status topics', err);
@@ -182,7 +188,15 @@ class MqttClient extends EventEmitter {
         },
       );
 
-      this.client.subscribe(getSubscribePath(), (err) => {
+      this.client.subscribe(
+        getSubscribePath(), 
+        {
+          qos: 1,
+          nl: true,  // don't echo back messages sent
+          rap: true, // retain as published - don't force retain = 0
+          rh: 0, // Retain handling 0 presumably ignores retained messages
+        },
+        (err) => {
         if (err) {
           logger.error('Unable to subscribe to control topics');
         }
@@ -312,7 +326,7 @@ class MqttClient extends EventEmitter {
         getTopicName(outputDevice.uniqueId, mqttType, TOPIC_TYPES.CONFIG),
         JSON.stringify(configPayload),
         {
-          retain: true,
+          retain: true,  // Discovery messages should be retained to account for HA restarts
           qos: 1,
         },
       );
@@ -321,7 +335,7 @@ class MqttClient extends EventEmitter {
           getTopicName(outputDevice.uniqueId, mqttType, TOPIC_TYPES.AVAILABILITY),
           AVAILABLILITY.ONLINE,
           {
-            retain: true,
+            retain: true,  // Discovery messages should be retained to account for HA restarts
             qos: 1,
           },
         );
@@ -348,7 +362,7 @@ class MqttClient extends EventEmitter {
         getTopicName(inputDevice.uniqueId, MQTT_TYPES.DEVICE_AUTOMATION, TOPIC_TYPES.CONFIG),
         JSON.stringify(inputInputPayload),
         {
-          retain: true,
+          retain: true, // Discovery messages should be retained to account for HA restarts
           qos: 1,
         },
       );
@@ -368,7 +382,7 @@ class MqttClient extends EventEmitter {
         getTopicName(sceneDevice.uniqueId, MQTT_TYPES.SCENE, TOPIC_TYPES.CONFIG),
         JSON.stringify(sceneConfigPayload),
         {
-          retain: true,
+          retain: true, // Discovery messages should be retained to account for HA restarts
           qos: 1,
         },
       );
@@ -383,7 +397,7 @@ class MqttClient extends EventEmitter {
         ),
         JSON.stringify(sceneTriggerConfigPayload),
         {
-          retain: true,
+          retain: true, // Discovery messages should be retained to account for HA restarts
           qos: 1,
         },
       );
@@ -393,7 +407,7 @@ class MqttClient extends EventEmitter {
           getTopicName(sceneDevice.uniqueId, MQTT_TYPES.SCENE, TOPIC_TYPES.AVAILABILITY),
           AVAILABLILITY.ONLINE,
           {
-            retain: true,
+            retain: true, // Discovery messages should be retained to account for HA restarts
             qos: 1,
           },
         );
@@ -439,13 +453,13 @@ class MqttClient extends EventEmitter {
 
     const mqttType = device.type === 'switch' ? MQTT_TYPES.SWITCH : MQTT_TYPES.LIGHT;
     this.client.publish(getTopicName(device.uniqueId, mqttType, TOPIC_TYPES.STATE), payload, {
-      retain: true,
+      retain: false,
       qos: 1,
     });
     // this.client.publish(
     //   getTopicName(device.uniqueId, mqttType, TOPIC_TYPES.AVAILABILITY),
     //   AVAILABLILITY.ONLINE,
-    //   { retain: true, qos: 1 },
+    //   { retain: false, qos: 1 },
     // );
   }
 
@@ -455,7 +469,10 @@ class MqttClient extends EventEmitter {
    */
   buttonPressed(deviceId, deviceInput) {
     logger.verbose(`Button ${deviceInput} pressed for deviceId ${deviceId}`);
-    this.client.publish(getButtonEventTopic(deviceId), `${deviceInput}`, { qos: 1 });
+    this.client.publish(getButtonEventTopic(deviceId), `${deviceInput}`, { 
+      retain: false,
+      qos: 1, 
+    });
   }
 
   /**
@@ -463,7 +480,10 @@ class MqttClient extends EventEmitter {
    */
   sceneTriggered(sceneId) {
     logger.verbose(`Scene triggered: ${sceneId}`);
-    this.client.publish(getSceneEventTopic(sceneId), '', { qos: 1 });
+    this.client.publish(getSceneEventTopic(sceneId), '', { 
+      qos: 1,
+      retain: false,
+    });
   }
 }
 

--- a/plejd/PlejdBLEHandler.js
+++ b/plejd/PlejdBLEHandler.js
@@ -663,7 +663,7 @@ class PlejBLEHandler extends EventEmitter {
     logger.info('Requesting current Plejd time...');
 
     const payload = this._createHexPayload(
-      this.connectedDevice.id,
+      this.connectedDeviceId,
       BLE_CMD_TIME_UPDATE,
       '',
       BLE_REQUEST_RESPONSE,

--- a/plejd/README.md
+++ b/plejd/README.md
@@ -42,7 +42,7 @@ Supported Plejd devices are detailed in a specific "Plejd devices" section below
 - Click on `Add-ons`
 - Click on `Add-on Store` in the bottom right corner of that page.
 - Click on the three vertical dots to the far right and chose `Repositories`
-- Paste the URL to this repo https://github.com/icanos/hassio-plejd.git in the `Add` field and hit `Add`.
+- Paste the URL to this repo <https://github.com/icanos/hassio-plejd.git> in the `Add` field and hit `Add`.
 - Scroll down and you should find a Plejd add-on that can be installed. Open that and install.
 - Configure hassio-plejd (see below).
 - Enjoy!
@@ -73,7 +73,7 @@ Please see the separate document [Details](./Details.md) for more detailed instr
 
 When starting the add-on, the log displays this message:
 
-```
+```log
 parse error: Expected string key before ':' at line 1, column 4
 [08:56:24] ERROR: Unknown HTTP error occured
 ```
@@ -97,7 +97,7 @@ Create a user in [Configuration -&gt; Users](https://my.home-assistant.io/redire
 
 For more advanced instllations, you need to add the MQTT integration to Home Assistant either by going to Configuration -> Integrations and clicking the Add Integration button, or by adding the following to your `configuration.yaml` file:
 
-```
+```yaml
 mqtt:
   broker: [point to your broker IP eg. 'mqtt://localhost']
   username: [username of mqtt broker]
@@ -192,18 +192,19 @@ If you're having issues to get the addon working, there are a few things you can
   - Plejd log will show something like `discovered light (DIM-01) named ....`
   - State change messages originate from the Plejd Bluetooth connection, so if you get those you should be able to listen to Plejd state changes as well as being able to set states!
   - Initial sync may take many minutes until all devices have the correct on/off/brightness states in HA
+- MQTT in Home Assistant will send birth and will messages that this addon listens to. If you have cases where Home Assistant sends these before this addon starts, consider reconfiguring Home Assistant MQTT to retain birth and will messages. See <https://www.home-assistant.io/integrations/mqtt/>
 - One Plejd device means max one BLE connection, meaning using the Plejd app over BT will disconnect the addon BLE connection
   - It seems you can kick yourself out (by connecting using the app) even when you have multiple devices if the app happens to connect to the same device as the addon is using
 
-## I want voice control!
+## I want voice control
 
 With the Google Home integration in Home Assistant, you can get voice control for your Plejd lights right away, check this out for more information:
-https://www.home-assistant.io/integrations/google_assistant/
+<https://www.home-assistant.io/integrations/google_assistant/>
 
-### I don't want voice, I want HomeKit!
+### I don't want voice, I want HomeKit
 
 Check this out for more information on how you can get your Plejd lights controlled using HomeKit:
-https://www.home-assistant.io/integrations/homekit/
+<https://www.home-assistant.io/integrations/homekit/>
 
 ## Developing
 
@@ -275,7 +276,7 @@ Out of the box you can for example view elapsed time by selecting multiple lines
 
 ## License
 
-```
+```text
 Copyright 2023 Marcus Westin <marcus@sekurbit.se>
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Startup behavior and switching state on Plejd lights have been issues for a long time. 

After a lot of investigation and several discussions in multiple tickets, the issue is related to SET STATE messages that are set as RETAIN by Home Assistant in MQTT and therefore sent to this addon on every startup.

This PR fixes that by forcefully removing those messages during startup. It also cleans up the startup flow and does cleanup and discovery both immediately and when Home Assistant sends a birth message over MQTT.

Resolves #218 

Replaces the PR #268

Does not address fetching the state from the Plejd mesh that #260 suggests.