### PR TITLE
Add experimental parsing for color temp support from Plejd API

### DIFF
--- a/plejd/MqttClient.js
+++ b/plejd/MqttClient.js
@@ -75,6 +75,12 @@ const getOutputDeviceDiscoveryPayload = (
     sw_version: device.version,
   },
   ...(device.type === MQTT_TYPES.LIGHT ? { brightness: device.dimmable, schema: 'json' } : {}),
+  ...(device.type === MQTT_TYPES.LIGHT && device.colorTempSettings?.behavior === "adjustable" ? {
+    color_mode: true,
+    min_mireds: 1000000 / device.colorTempSettings.minTemperatureLimit,
+    max_mireds: 1000000 / device.colorTempSettings.maxTemperatureLimit,
+    supported_color_modes: ["color_temp"],
+  } : {}),
 });
 
 const getSceneDiscoveryPayload = (
@@ -321,9 +327,6 @@ class MqttClient extends EventEmitter {
         `Sent discovery message for ${outputDevice.typeName} (${outputDevice.type}) named ${outputDevice.name} (${outputDevice.bleOutputAddress} : ${outputDevice.uniqueId}).`,
       );
 
-
-      
-    
       // -------- CLEANUP RETAINED MESSAGES FOR OUTPUT DEVICES -------------
 
       logger.debug(
@@ -354,7 +357,6 @@ class MqttClient extends EventEmitter {
 
       logger.debug(`Removal messages sent for ${outputDevice.name}`);
 
-      
       logger.debug(`Setting device as AVAILABILITY = ONLINE: ${outputDevice.name}`);
 
       this.client.publish(
@@ -441,8 +443,6 @@ class MqttClient extends EventEmitter {
       );
     });
 
-
-    
     // -------- SUBSCRIBE TO INCOMING MESSAGES -------------
 
     this.client.subscribe(

--- a/plejd/PlejdApi.js
+++ b/plejd/PlejdApi.js
@@ -339,8 +339,10 @@ class PlejdApi {
           description: 'Dali broadcast with dimmer and tuneable white support',
           type: 'light',
           dimmable: true,
+          colorTemp: true,
           broadcastClicks: false,
         };
+      // 13: Non-dimmable generic light
       case 14:
         return {
           name: 'DIM-01',
@@ -388,6 +390,7 @@ class PlejdApi {
           description: '1-channel LED dimmer/driver with tuneable white, 10 W',
           type: 'light',
           dimmable: true,
+          colorTemp: true,
           broadcastClicks: false,
         };
       case 167:
@@ -396,6 +399,7 @@ class PlejdApi {
           description: 'Smart tunable downlight with a built-in dimmer function, 8W',
           type: 'light',
           dimmable: true,
+          colorTemp: true,
           broadcastClicks: false,
         };
       case 199:
@@ -404,6 +408,7 @@ class PlejdApi {
           description: 'Smart tunable downlight with a built-in dimmer function, 8W',
           type: 'light',
           dimmable: true,
+          colorTemp: true,
           broadcastClicks: false,
         };
       // PLEASE CREATE AN ISSUE WITH THE HARDWARE ID if you own one of these devices!
@@ -499,6 +504,8 @@ class PlejdApi {
             /** @type {import('types/DeviceRegistry').OutputDevice} */
             const outputDevice = {
               bleOutputAddress,
+              colorTemp,
+              colorTempSettings: outputSettings.colorTemperature,
               deviceId: device.deviceId,
               dimmable,
               name: device.title,
@@ -604,6 +611,7 @@ class PlejdApi {
         const newDevice = {
           bleOutputAddress: roomAddress,
           deviceId: null,
+          colorTemp: false,
           dimmable,
           name: room.title,
           output: undefined,
@@ -633,6 +641,7 @@ class PlejdApi {
       /** @type {import('types/DeviceRegistry').OutputDevice} */
       const newScene = {
         bleOutputAddress: sceneNum,
+        colorTemp: false,
         deviceId: undefined,
         dimmable: false,
         name: scene.title,

--- a/plejd/types/ApiSite.d.ts
+++ b/plejd/types/ApiSite.d.ts
@@ -260,6 +260,7 @@ export interface OutputSetting {
   deviceParseId: string;
   siteId: string;
   predefinedLoad: OutputSettingPredefinedLoad;
+  colorTemperature: OutputSettingColorTemperature;
   createdAt: Date;
   updatedAt: Date;
   dimMin: number;
@@ -320,6 +321,16 @@ export interface OutputSettingPredefinedLoad {
   className: PredefinedLoadClassName;
   supportMessage?: SupportMessage;
   filters?: Filters;
+}
+
+export interface OutputSettingColorTemperature {
+  "minTemperature": number,
+  "maxTemperature": number,
+  "slewRate": number,
+  "minTemperatureLimit": number,
+  "maxTemperatureLimit": number,
+  "behavior": "adjustable" | "UNKNOWN", // Todo: Fill with alternate values after finding more site jsons. UNKNOWN is placeholder for now.
+  "startTemperature": number
 }
 
 export interface PredefinedLoadACL {

--- a/plejd/types/DeviceRegistry.d.ts
+++ b/plejd/types/DeviceRegistry.d.ts
@@ -1,9 +1,13 @@
 /* eslint-disable no-use-before-define */
 
+import { OutputSettingColorTemperature } from "./ApiSite";
+
 export type OutputDevices = { [deviceIdAndOutput: string]: OutputDevice };
 
 export interface OutputDevice {
   bleOutputAddress: number;
+  colorTemp: boolean;
+  colorTempSettings?: OutputSettingColorTemperature
   deviceId: string;
   dim?: number;
   dimmable: boolean;


### PR DESCRIPTION
Plejd supports color temperature setting on top of dimming.

This PR is an experimental first step to try to implement support.

## Expected functionality
* Color temperature-capable devices show up as such in Home Assistant
* It is possible to set color temp in the correctly supported range from HA
* Nothing happens when setting color temp

## Help needed
I don't personally own any color temperature capable Plejd devices, so I will need **logs from the silly level** minimally showing
* Site JSON response (remove sensitive info)
* Discovery phase
* Setting values in HA with resulting MQTT messages and parsing of those
* Logs uploaded as files to not spam chat too much

## Remaining steps
* Verify parsing of `traits` in `PlejdApi.js`
* Verify that MQTT discovery to HA is correct and that devices are registered correctly
* View and parse MQTT messages from HA setting state including color temperature
* Implement new BLE commands to support color temperature
