### PR TITLE
Added Home assistant Yellow to tested devices

### DIFF
--- a/plejd/README.md
+++ b/plejd/README.md
@@ -32,6 +32,7 @@ The add-on has been tested on the following platforms:
 - Windows 10 Pro host / Oracle VirtualBox 6.1 / Home Assistant VBox image / Deltaco BT-118 with Cambridge Silicon Radio chipset / Windows + Zadig to change driver to WinUSB
 - Windows 10 host / Oracle Virtualbox 6.1 / Home Assistant VBox image / ASUS BT400
 - Mac OS Catalina 10.15.1 with Node v. 13.2.0
+- Home Assistant Yellow with RPI 4 compute module / Built-in BT
 
 Supported Plejd devices are detailed in a specific "Plejd devices" section below.
 


### PR DESCRIPTION
I have been running this add-on on my Home Assistant Yellow with an RPI 4 Compute Module, using the built-in Bluetooth, for about a year without encountering any issues.

While I’ve noticed some reports from others about "passive scanning" causing problems with Bluetooth, I haven’t experienced any such issues with this setup.